### PR TITLE
Change relative zone file path to absolute path

### DIFF
--- a/mmbop.py
+++ b/mmbop.py
@@ -740,10 +740,11 @@ class RNDC:
         file_name = self.write_zone_file(zone_name, empty_zone_file)
         if not file_name:
             return (False, 'Unable to place zone file in named directory. Check permissions.')
+        file_path = self.info['namedir'] + file_name
         add_commands = 'addzone ' + zone_name + ' '
         if self.info['view']:
             add_commands += 'IN ' + self.info['view'] + ' '
-        add_commands += ' { type master; file "' + file_name + '"; '
+        add_commands += ' { type master; file "' + file_path + '"; '
         for opt_line in self.info['options']:
             add_commands += opt_line + ' '
         add_commands += "};"


### PR DESCRIPTION
When using a zone file path that isn't the default `/etc/bind`, `addzone` fails because the RNDC call uses a relative path, resulting in RNDC failing because it can't find the new zone file in the `/etc/bind` directory. By referencing the new zone file with it's absolute path, we guarantee that regardless of where the zone files are stored, RNDC will correctly be able to find it.